### PR TITLE
Changed target storageEngine references

### DIFF
--- a/HowToMigrate.md
+++ b/HowToMigrate.md
@@ -1,4 +1,4 @@
-# TokuMX 2.0.x to Percona Server for MongoDB 3.0.x migration
+# TokuMX 2.0.x to Percona Server for MongoDB 3.x migration
 
 1. Restart the tokumx server without the `--auth` parameter
 
@@ -42,10 +42,20 @@
 
 9. Stop the service and configure the storageEngine and turn off `--auth` in `/etc/mongod.conf`
 
+   **For WiredTiger**
+
         service mongod stop
 
         sed -i'' s/^storageEngine/#storageEngine/ /etc/mongod.conf
-        sed -i'' s/^#storageEngine=PerconaFT/storageEngine=PerconaFT/ /etc/mongod.conf
+        sed -i'' s/^#storageEngine=wiredTiger/storageEngine=wiredTiger/ /etc/mongod.conf
+        sed -i'' s/^auth/#auth/ /etc/mongod.conf
+
+   **For RocksDB**
+
+        service mongod stop
+
+        sed -i'' s/^storageEngine/#storageEngine/ /etc/mongod.conf
+        sed -i'' s/^#storageEngine=rocksdb/storageEngine=rocksdb/ /etc/mongod.conf
         sed -i'' s/^auth/#auth/ /etc/mongod.conf
 
 10. Start the server

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # tokumx2_to_psmdb3_migration
 
-Instructions and scripts to facilitate migration from TokuMX 2.0.x to PSMDB 3.0.x
+Instructions and scripts to facilitate migration from TokuMX 2.0.x to PSMDB 3.x

--- a/ZeroDowntimeMigration.md
+++ b/ZeroDowntimeMigration.md
@@ -254,26 +254,32 @@ default mongod port 27017.  You will need to configure the system firewall,
 test connectivity and use authentication as required which is outside the
 scope of this document.
 
-1. Configure your new target server for use with the PerconaFT storage engine.
-   This can be accomplished in two ways:
+1. Configure your new target server for use with the WiredTiger or RocksDB 
+   storage engine. This can be accomplished in two ways:
 
     * The servers `/etc/mongo.conf` configuration file can be modified to enable
-    the PerconaFT storage engine:
+    the new storage engine:
 
       ```
       storage:
-        engine: PerconaFT
+        engine: wiredTiger 
+      ```
+      or
+
+      ```
+      storage:
+        engine: rocksdb  
       ```
 
     * Or, the command line used to start the server can be amended with the
-    `--storageEngine=PerconaFT` parameter.
+    `--storageEngine=wiredTiger` or `--storageEngine=rocksdb` parameter.
 
     *Note:* A storage engine change requires completely purging the data
     directory, so this should be done on new PSMDB 3.x server.  For PSMDB 3.x
     installed from Percona packaging, the steps are:
 
     1. Stop the server
-    2. Modify the `/etc/mongo.conf` configuration to use PerconaFT
+    2. Modify the `/etc/mongo.conf` configuration to use wiredTiger or rocksdb
     3. Delete all contents in the `/var/lib/mongo` directory
     4. Start the server (default data files will be created automatically)
 


### PR DESCRIPTION
Now that PerconaFT is deprecated, it is recommended to migrate to
wiredTiger or rocksdb.