### PR TITLE
Fixed documentation when using authentication

### DIFF
--- a/ZeroDowntimeMigration.md
+++ b/ZeroDowntimeMigration.md
@@ -233,6 +233,7 @@ PSMDB 3.x target.
     # rm -rf /var/lib/tokumx_backup
     ```
 6. ONLY IF USING AUTHENTICATION
+
    If you are running tokumx with authentication it will be necessary to convert the users collection.
    It will be necessary a MongoDB version 2.6 to perform this operation, this can be found [here] (http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.6.12.tgz)
    

--- a/ZeroDowntimeMigration.md
+++ b/ZeroDowntimeMigration.md
@@ -235,6 +235,7 @@ PSMDB 3.x target.
 6. ONLY IF USING AUTHENTICATION
    If you are running tokumx with authentication it will be necessary to convert the users collection.
    It will be necessary a MongoDB version 2.6 to perform this operation, this can be found [here] (http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.6.12.tgz)
+   
    6.1) Start a mongodb 2.6 in a temp directory:
    ```
    # mkdir /tmp/mongo2.6
@@ -256,7 +257,7 @@ PSMDB 3.x target.
    ```
    #mongodump --port 27000 -d admin -o tokumx2_dump
    ```
-   6.4) At the end of this process the admin database will be ready to be restored in any MongoDB 3+
+   At the end of this process the admin database will be ready to be restored in any MongoDB 3+
 
 
 ## Phase 3 - Restore <a name="restore"></a>

--- a/ZeroDowntimeMigration.md
+++ b/ZeroDowntimeMigration.md
@@ -232,6 +232,32 @@ PSMDB 3.x target.
     # mongod --port=27018 --dbpath=/var/lib/tokumx_backup --shutdown
     # rm -rf /var/lib/tokumx_backup
     ```
+6. ONLY IF USING AUTHENTICATION
+   If you are running tokumx with authentication it will be necessary to convert the users collection.
+   It will be necessary a MongoDB version 2.6 to perform this operation, this can be found [here] (http://downloads.mongodb.org/linux/mongodb-linux-x86_64-2.6.12.tgz)
+   6.1) Start a mongodb 2.6 in a temp directory:
+   ```
+   # mkdir /tmp/mongo2.6
+   # mongod --dbpath /tmp/mongo2.6 --logpath /tmp/mongo2.6/log.log --fork --smallfiles --port 27000
+   ```
+   6.2) Restore only the admin database using a 2.4 mongorestore.
+   ```
+   # mongorestore --port 27000 -d admin tokumx2_dump/admin
+   # mv tokumx2_dump/admin /tmp/
+   ```
+   6.3) Connect to the mongodb 2.6 with a mongo 2.6 client and run the following commands, we expect to see an output similar to: 
+   ```
+   #mongo --port 27000
+   > use admin
+   > db.adminCommand({authSchemaUpgrade: 1 });
+   { "done" : true, "ok" : 1 }
+   ```
+   6.4) Dump the 2.6 admin collection and move the folder to the 2.4 (tokuMX) backup, this can be done with a single command like:
+   ```
+   #mongodump --port 27000 -d admin tokumx2_dump
+   ```
+   6.4) At the end of this process the admin database will be ready to be restored in any MongoDB 3+
+
 
 ## Phase 3 - Restore <a name="restore"></a>
 

--- a/ZeroDowntimeMigration.md
+++ b/ZeroDowntimeMigration.md
@@ -254,7 +254,7 @@ PSMDB 3.x target.
    ```
    6.4) Dump the 2.6 admin collection and move the folder to the 2.4 (tokuMX) backup, this can be done with a single command like:
    ```
-   #mongodump --port 27000 -d admin tokumx2_dump
+   #mongodump --port 27000 -d admin -o tokumx2_dump
    ```
    6.4) At the end of this process the admin database will be ready to be restored in any MongoDB 3+
 
@@ -269,7 +269,7 @@ TokuMX 2.x and run on a separate port which may be faster depending on space
 availability, network and block device speeds and existing load.
 
 You will need to install the `mongorestore` binary from PSMDB 3.x onto
-a system that has direct file access to your tokumx2_dump image created in the
+a system that has direct file access to your image created in the
 dump phase.  Luckily, `mongorestore` has very few dynamic dependencies and is
 very portable from system to system.
 


### PR DESCRIPTION
Covering authentication and how to upgrade the users.
As the 2.4 users are not compatible with 3.0+ I've added how to upgrade the users to the new standard.